### PR TITLE
Sales Forecasting UI improvements

### DIFF
--- a/sales-forecasting/requirements.txt
+++ b/sales-forecasting/requirements.txt
@@ -3,7 +3,7 @@ botocore==1.19.23
 certifi==2020.11.8; python_version >= "3.6" and python_full_version >= "3.6.1"
 click==7.1.2; python_full_version >= "3.6.1"
 h11==0.11.0; python_version >= "3.6" and python_full_version >= "3.6.1"
-h2o-wave<1.0; python_full_version >= "3.6.1"
+h2o-wave==0.13; python_full_version >= "3.6.1"
 httpcore==0.12.2; python_version >= "3.6" and python_full_version >= "3.6.1"
 httpx==0.16.1; python_version >= "3.6" and python_full_version >= "3.6.1"
 idna==2.10; python_version >= "3.6" and python_full_version >= "3.6.1"

--- a/sales-forecasting/requirements.txt
+++ b/sales-forecasting/requirements.txt
@@ -3,7 +3,7 @@ botocore==1.19.23
 certifi==2020.11.8; python_version >= "3.6" and python_full_version >= "3.6.1"
 click==7.1.2; python_full_version >= "3.6.1"
 h11==0.11.0; python_version >= "3.6" and python_full_version >= "3.6.1"
-h2o-wave==0.13; python_full_version >= "3.6.1"
+h2o-wave<1.0; python_full_version >= "3.6.1"
 httpcore==0.12.2; python_version >= "3.6" and python_full_version >= "3.6.1"
 httpx==0.16.1; python_version >= "3.6" and python_full_version >= "3.6.1"
 idna==2.10; python_version >= "3.6" and python_full_version >= "3.6.1"


### PR DESCRIPTION
Before:
<img width="1679" alt="Screen Shot 2021-03-10 at 3 31 05 PM" src="https://user-images.githubusercontent.com/64769322/110647002-c0e28100-81b7-11eb-948c-c954819c595f.png">
After:
<img width="1679" alt="Screen Shot 2021-03-10 at 3 42 26 PM" src="https://user-images.githubusercontent.com/64769322/110647024-c63fcb80-81b7-11eb-91c4-3b569b0a2a27.png">

* Removed the horizontal scrollbars appearing on smaller screens (1st pic is taken at my MacBook).
* Removed unnecessary tooltips and gaps.
* Cleaned up the code a bit by removing hardcoded colors used for range.
* Fixed bug that prevented users from selecting 0 weeks.

Future possible improvements:
* I tried to change department and store IDs to their real names, but noticed the datasets do not provide such info so I guess it has to stay this way.
* If needed, can make the whole app responsive to look good on mobile devices as well.
* @srini-x not sure if I understood correctly, but we don't really need to download the csvs from S3 for every single user like we do now, right? From my understanding, this could be fetched just once (in `on_startup` hook for example) so that users won't be bothered by the loading. Please, correct me if I am wrong though.