### PR TITLE
Make churn predictor data agnostic

### DIFF
--- a/churn-risk/src/app.py
+++ b/churn-risk/src/app.py
@@ -8,11 +8,25 @@ from pygments.lexers import get_lexer_by_name
 from h2o_wave import app, main, Q, ui, data
 from .churn_predictor import ChurnPredictor
 
-df = pd.read_csv('data/churnTest.csv')
+
+TRAIN_DATASET_PATH='./data/churnTrain.csv'
+TEST_DATASET_PATH='./data/churnTest.csv'
+TARGET_COLUMN="Churn?"
+CATEGORICAL_COLUMNS=['Area Code']
+DROP_COLUMNS=["Phone"]
+
+df = pd.read_csv(TEST_DATASET_PATH)
 df.dropna(inplace=True)
 df['Total Charges'] = (df['Day Charges'] + df['Evening Charges'] + df['Night Charges'] + df['Intl Charges'])
 rank = df['Total Charges'].rank(pct=True).values[0]
-churn_predictor = ChurnPredictor()
+
+churn_predictor = ChurnPredictor(
+    train_dataset_path=TRAIN_DATASET_PATH,
+    test_dataset_path=TEST_DATASET_PATH,
+    target_column=TARGET_COLUMN,
+    categorical_columns=CATEGORICAL_COLUMNS,
+    drop_columns=DROP_COLUMNS,
+)
 
 
 def render_shap_plot(q: Q, shap_rows: List, selected_row_index: Optional[int]):

--- a/churn-risk/src/churn_predictor.py
+++ b/churn-risk/src/churn_predictor.py
@@ -11,30 +11,39 @@ class ChurnPredictor:
     giving the developer freedom to integrate any 3rd party machine library with a minimal change to the app code.
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        train_dataset_path: str,
+        test_dataset_path: str,
+        target_column: str,
+        categorical_columns: Optional[List[str]] = None,
+        drop_columns: Optional[List[str]] = None
+    ):
         h2o.init()
-        # Initialize H2O-3 model and tests data set
-        self.train_df = h2o.import_file(path='./data/churnTrain.csv', destination_frame="telco_churn_train.csv")
-        self.train_df['Area Code'] = self.train_df['Area Code'].asfactor()
 
-        train, valid = self.train_df.split_frame([0.8])
-        self.model = H2OGradientBoostingEstimator(model_id="telco_churn_model", seed=1234)
+        self.train_df = h2o.import_file(path=train_dataset_path, destination_frame="churn_train.csv")
+        self.test_df = h2o.import_file(path=test_dataset_path, destination_frame="churn_test.csv")
 
-        columns_to_train = self.train_df.columns
-        columns_to_train.remove("Churn?")
-        columns_to_train.remove("Phone")
+        if categorical_columns is not None:
+            for column in categorical_columns:
+                self.train_df[column] = self.train_df[column].asfactor()
+                self.test_df[column] = self.test_df[column].asfactor()
 
-        self.model.train(x=columns_to_train, y="Churn?", training_frame=train, validation_frame=valid)
+        feature_columns = self.train_df.columns
+        feature_columns.remove(target_column)
+        if drop_columns is not None:
+            for column in drop_columns:
+                feature_columns.remove(column)
 
-        self.h2o_test_df = h2o.import_file(path='./data/churnTest.csv', destination_frame="telco_churn_test.csv")
-        self.h2o_test_df['Area Code'] = self.h2o_test_df['Area Code'].asfactor()
+        train, valid = self.train_df.split_frame([0.8], seed=1234)
+        self.model = H2OGradientBoostingEstimator(model_id="churn_model", seed=1234)
+        self.model.train(x=feature_columns, y=target_column, training_frame=train, validation_frame=valid)
 
-        self.predicted_df = self.model.predict(self.h2o_test_df).as_data_frame()
-        self.contributions_df = self.model.predict_contributions(self.h2o_test_df).drop('BiasTerm').as_data_frame()
+        self.churn_probabilities = self.model.predict(self.test_df)[:,-1].as_data_frame()
+        self.contributions_df = self.model.predict_contributions(self.test_df).drop('BiasTerm').as_data_frame()
 
     def get_churn_rate(self, row_index: Optional[int]) -> float:
-        predict_col = self.predicted_df["TRUE"]
-        churn = predict_col[row_index] if row_index is not None else predict_col.mean(axis=0)
+        churn = self.churn_probabilities[row_index] if row_index is not None else self.churn_probabilities.mean(axis=0)
         return round(float(churn) * 100, 2)
 
     def get_shap(self, row_index: Optional[int]) -> List[Tuple[Any, Any]]:
@@ -42,8 +51,8 @@ class ChurnPredictor:
         np_row = np_row.to_numpy()
         shap = [(self.contributions_df.columns[i], np_row[i]) for i in range(len(self.contributions_df.columns))]
         shap.sort(key=lambda e : e[1])
-        return shap 
-    
+        return shap
+
     def get_negative_explanation(self, row_index: Optional[int], min_contrib_col: Optional[str]) -> Tuple[bool, Any, List]:
         contribs = min_contrib_col or self.contributions_df.idxmin(axis=1)[row_index]
         return self._get_explanation(contribs, row_index)
@@ -55,22 +64,22 @@ class ChurnPredictor:
     @staticmethod
     def get_python_type(val) -> Union[str, float, int]:
         return val if isinstance(val, (str, float)) else val.item()
-        
+
     @classmethod
     def _get_size(cls, group_size, idx: int) -> Union[str, float, int]:
         return 0 if idx > len(group_size) - 1 else cls.get_python_type(group_size[idx])
 
     def _get_explanation(self, contrib, row_index: Optional[int]) -> Tuple[bool, Any, List]:
-        contrib_col = self.h2o_test_df[contrib]
+        contrib_col = self.test_df[contrib]
         partial_plot = self.model.partial_plot(
-            self.h2o_test_df, 
+            self.test_df,
             plot=False,
             cols=[contrib],
             nbins=contrib_col.nlevels()[0] + 1 if contrib_col.isfactor()[0] else 20,
             row_index=row_index
         )[0].as_data_frame()
 
-        if self.h2o_test_df.type(contrib) in ['int', 'real']:
+        if self.test_df.type(contrib) in ['int', 'real']:
             bins = [contrib_col.na_omit().min()] + partial_plot.iloc[:, 0].tolist() + [contrib_col.na_omit().max()]
 
             group_by_size = contrib_col.cut(


### PR DESCRIPTION
Parameterizes the `ChurnPredictor` class so that any train and test csv
can be specified.

Partially addresses #50 