### PR TITLE
Updated broken link pointing to the wave installation page 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ H2O Wave allows you to build AI apps, faster. This directory houses sample appli
 
 ## Installation 
 
-Follow the instructions [here](https://h2oai.github.io/wave/docs/installation) to download and run the latest Wave Server, a requirement for all sample apps. Then, choose an app from below for setup instructions.
+Follow the instructions [here](https://wave.h2o.ai/docs/installation) to download and run the latest Wave Server, a requirement for all sample apps. Then, choose an app from below for setup instructions.
 
 
 
-## Available Apps
+## Available Apps 
 
 ### [Explainable Hotel Ratings](explaining-ratings/README.md)
 

--- a/credit-risk/README.md
+++ b/credit-risk/README.md
@@ -15,7 +15,7 @@ This application builds a model using H2O Wave ML to predict if a customer will 
 3. JRE 11+ (needed to run H2O-3) 
 
 ### 1. Run the Wave Server
-New to H2O Wave? We recommend starting in the documentation to [download and run](https://h2oai.github.io/wave/docs/installation) the Wave Server on your local machine. Once the server is up and running you can easily use any Wave app. 
+New to H2O Wave? We recommend starting in the documentation to [download and run](https://wave.h2o.ai/docs/installation) the Wave Server on your local machine. Once the server is up and running you can easily use any Wave app. 
 
 ### 2. Setup Your Python Environment
 

--- a/explaining-ratings/README.md
+++ b/explaining-ratings/README.md
@@ -13,7 +13,7 @@ This application allows users to build word clouds on the hotel reviews texts. I
 
 ### 1. Run the Wave Server
 
-New to H2O Wave? We recommend starting in the documentation to [download and run](https://h2oai.github.io/wave/docs/installation) the Wave Server on your local machine. Once the server is up and running you can easily use any Wave app.
+New to H2O Wave? We recommend starting in the documentation to [download and run](https://wave.h2o.ai/docs/installation) the Wave Server on your local machine. Once the server is up and running you can easily use any Wave app.
 
 ### 2. Setup Your Python Environment
 

--- a/guess-the-number/README.md
+++ b/guess-the-number/README.md
@@ -62,7 +62,7 @@ The previous section will help get the app up and running. However, the player i
 
 [wave-installation-term-gif]: ./static/install_wave_server_term.gif
 [wave-app-env-setup-term-gif]: ./static/wave_app_env_setup_term.gif
-[wave-docs-installation]: https://h2oai.github.io/wave/docs/installation
+[wave-docs-installation]: https://wave.h2o.ai/docs/installation
 [wave-app-state]: https://h2oai.github.io/wave/docs/state
 [wave-single-sign-on]: https://h2oai.github.io/wave/docs/security#single-sign-on
 [auth-dev-setup-keycloak]: ./dev_authentication_setup.md

--- a/sales-forecasting/README.md
+++ b/sales-forecasting/README.md
@@ -10,7 +10,7 @@ This application uses predictions made from Driverless AI but doesn't explicitly
 2. pip3
 
 ### 1. Run the Wave Server
-New to H2O Wave? We recommend starting in the documentation to [download and run](https://h2oai.github.io/wave/docs/installation) the Wave Server on your local machine. Once the server is up and running you can easily use any Wave app. 
+New to H2O Wave? We recommend starting in the documentation to [download and run](https://wave.h2o.ai/docs/installation) the Wave Server on your local machine. Once the server is up and running you can easily use any Wave app. 
 
 ### 2. Setup Your Python Environment
 

--- a/shopping-cart-recommendations/README.md
+++ b/shopping-cart-recommendations/README.md
@@ -13,7 +13,7 @@ This application provides product suggestions based on user's active cart using 
 
 
 ### 1. Run the Wave Server
-New to H2O Wave? We recommend starting in the documentation to [download and run](https://h2oai.github.io/wave/docs/installation) the Wave Server on your local machine. Once the server is up and running you can easily use any Wave app. 
+New to H2O Wave? We recommend starting in the documentation to [download and run](https://wave.h2o.ai/docs/installation) the Wave Server on your local machine. Once the server is up and running you can easily use any Wave app. 
 
 ### 2. Setup Your Python Environment
 

--- a/twitter-sentiment/README.md
+++ b/twitter-sentiment/README.md
@@ -16,7 +16,7 @@ This application allows you to search for Twitter hashtags and do sentiment anal
 
 ### 1. Run the Wave Server
 
-New to H2O Wave? We recommend starting in the documentation to [download and run](https://h2oai.github.io/wave/docs/installation) the Wave Server on your local machine. Once the server is up and running you can easily use any Wave app.
+New to H2O Wave? We recommend starting in the documentation to [download and run](https://wave.h2o.ai/docs/installation) the Wave Server on your local machine. Once the server is up and running you can easily use any Wave app.
 
 ### 2. Setup Your Python Environment
 


### PR DESCRIPTION
Updated broken link pointing to the wave installation page on the main Readme and in all the subsequent apps.