### PR TITLE
Update `Makefile` in all projects

### DIFF
--- a/churn-risk/README.md
+++ b/churn-risk/README.md
@@ -23,19 +23,12 @@ New to H2O Wave? We recommend starting in the documentation to [download and run
 git clone git@github.com:h2oai/wave-apps.git
 cd wave-apps/churn-risk
 make setup
-source venv/bin/activate
 ```
 
 ### 3. Run the App
 
 ```bash
-wave run src.app
-```
-
-Note! If you did not activate your virtual environment this will be:
-
-```bash
-./venv/bin/wave run src.app
+make run
 ```
 
 ### 4. View the App
@@ -74,5 +67,5 @@ python3 ~/wave/test/cypress.py -m src.app
 else if you want to launch a new Wave instance automatically,
 
 ```bash
-    python3 ~/wave/test/cypress.py -m src.app -w ~/wave/waved -wd ~/wave/www
+python3 ~/wave/test/cypress.py -m src.app -w ~/wave/waved -wd ~/wave/www
 ```

--- a/credit-risk/Makefile
+++ b/credit-risk/Makefile
@@ -1,22 +1,24 @@
-all: ## Build wheel
-	zip -r \
-        --exclude=".git/*" \
-        --exclude="/venv/*" \
-        --exclude="*.csv" \
-        --exclude="*__pycache__/*" \
-        $(shell basename $$PWD).qz .
+SHELL      := bash
+PYTHON     := python3
 
-setup: ## Create venv and install dependencies on it
-	python3 -m venv venv
-	./venv/bin/pip install -U pip
-	./venv/bin/pip install wheel
-	./venv/bin/pip install -r requirements.txt
+.DEFAULT_GOAL := help
 
-install: ## Install dependencies on active python environment
-	pip install -r requirements.txt
+venv:
+	$(PYTHON) -m venv venv
 
-clean: ## Clean
-	rm -rf dist venv *.whl *.qz
+.PHONY: setup
+setup: | venv ## Setup a project
+	./venv/bin/python -m pip install -U pip
+	./venv/bin/python -m pip install -r requirements.txt
 
+.PHONY: run
+run: ## Run the App (run `make setup` first)
+	./venv/bin/wave run src.app
+
+.PHONY: clean
+clean: ## Remove all files produced by `make`
+	rm -rf venv
+
+.PHONY: help
 help: ## List all make tasks
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/credit-risk/README.md
+++ b/credit-risk/README.md
@@ -20,21 +20,15 @@ New to H2O Wave? We recommend starting in the documentation to [download and run
 ### 2. Setup Your Python Environment
 
 ```bash
-$ git clone git@github.com:h2oai/wave-apps.git
-$ cd wave-apps/credit-risk
-$ make setup
-$ source venv/bin/activate
+git clone git@github.com:h2oai/wave-apps.git
+cd wave-apps/credit-risk
+make setup
 ```
 
 ### 3. Run the App
 
 ```bash
-wave run src.app
-```
-
-Note! If you did not activate your virtual environment this will be:
-```bash
-./venv/bin/wave run src.app
+make run
 ```
 
 ### 4. View the App

--- a/explaining-ratings/Makefile
+++ b/explaining-ratings/Makefile
@@ -1,22 +1,24 @@
-all: ## Build wheel
-	zip -r \
-        --exclude=".git/*" \
-        --exclude="/venv/*" \
-        --exclude="*.csv" \
-        --exclude="*__pycache__/*" \
-        $(shell basename $$PWD).qz .
+SHELL      := bash
+PYTHON     := python3
 
-setup: ## Create venv and install dependencies on it
-	python3 -m venv venv
-	./venv/bin/pip install -U pip
-	./venv/bin/pip install wheel
-	ARCHFLAGS="-arch x86_64" ./venv/bin/pip install -r requirements.txt
+.DEFAULT_GOAL := help
 
-install: ## Install dependencies on active python environment
-	ARCHFLAGS="-arch x86_64" pip install -r requirements.txt
+venv:
+	$(PYTHON) -m venv venv
 
-clean: ## Clean
-	rm -rf dist venv *.whl *.qz
+.PHONY: setup
+setup: | venv ## Setup a project
+	./venv/bin/python -m pip install -U pip
+	./venv/bin/python -m pip install -r requirements.txt
 
+.PHONY: run
+run: ## Run the App (run `make setup` first)
+	./venv/bin/wave run src.app
+
+.PHONY: clean
+clean: ## Remove all files produced by `make`
+	rm -rf venv
+
+.PHONY: help
 help: ## List all make tasks
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/explaining-ratings/README.md
+++ b/explaining-ratings/README.md
@@ -21,19 +21,12 @@ New to H2O Wave? We recommend starting in the documentation to [download and run
 git clone git@github.com:h2oai/wave-apps.git
 cd wave-apps/explaining-ratings
 make setup
-source venv/bin/activate
 ```
 
 ### 3. Run the App
 
 ```bash
-wave run src.app
-```
-
-Note! If you did not activate your virtual environment this will be:
-
-```bash
-./venv/bin/wave run src.app
+make run
 ```
 
 ### 4. View the App

--- a/guess-the-number/Makefile
+++ b/guess-the-number/Makefile
@@ -13,7 +13,7 @@ setup: | venv ## Setup a project
 
 .PHONY: run
 run: ## Run the App (run `make setup` first)
-	./venv/bin/wave run src.app
+	./venv/bin/wave run guess_the_number.guess
 
 .PHONY: clean
 clean: ## Remove all files produced by `make`

--- a/guess-the-number/README.md
+++ b/guess-the-number/README.md
@@ -31,22 +31,18 @@ scores against each other.
 
 - Need Python `3.7.9 +`
 
-```console
-$ git clone https://github.com/h2oai/wave-apps.git
-$ cd wave-apps/guess-the-number
-$ python3 -m venv venv
-$ source venv/bin/activate
-$ pip install -r requirements.txt
+```bash
+git clone https://github.com/h2oai/wave-apps.git
+cd wave-apps/guess-the-number
+make setup
 ```
-
-![wave-app-env-setup-term-gif]
 
 [Top](#guess-the-number)
 
 #### 3. Run the app by pointing to the module directory
 
-```console
-$ wave run guess_the_number/guess.py
+```bash
+make run
 ```
 
 - Point your web browser to `localhost:10101`. In the future, if you want to run this app you can skip step 2 as the environment is already set up.

--- a/insurance-churn-risk/Makefile
+++ b/insurance-churn-risk/Makefile
@@ -1,22 +1,24 @@
-all: ## Build wheel
-	zip -r \
-        --exclude=".git/*" \
-        --exclude="/venv/*" \
-        --exclude="*.csv" \
-        --exclude="*__pycache__/*" \
-        $(shell basename $$PWD).qz .
+SHELL      := bash
+PYTHON     := python3
 
-setup: ## Create venv and install dependencies on it
-	python3 -m venv venv
-	./venv/bin/pip install -U pip
-	./venv/bin/pip install wheel
-	./venv/bin/pip install -r requirements.txt
-      
-install: ## Install dependencies on active python environment
-	pip install -r requirements.txt
+.DEFAULT_GOAL := help
 
-clean: ## Clean
-	rm -rf dist venv *.whl *.qz
+venv:
+	$(PYTHON) -m venv venv
 
+.PHONY: setup
+setup: | venv ## Setup a project
+	./venv/bin/python -m pip install -U pip
+	./venv/bin/python -m pip install -r requirements.txt
+
+.PHONY: run
+run: ## Run the App (run `make setup` first)
+	./venv/bin/wave run src.app
+
+.PHONY: clean
+clean: ## Remove all files produced by `make`
+	rm -rf venv
+
+.PHONY: help
 help: ## List all make tasks
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/insurance-churn-risk/README.md
+++ b/insurance-churn-risk/README.md
@@ -23,19 +23,12 @@ New to H2O Wave? We recommend starting in the documentation to [download and run
 git clone git@github.com:h2oai/wave-apps.git
 cd wave-apps/churn-risk
 make setup
-source venv/bin/activate
 ```
 
 ### 3. Run the App
 
 ```bash
-wave run src.app
-```
-
-Note! If you did not activate your virtual environment this will be:
-
-```bash
-./venv/bin/wave run src.app
+make run
 ```
 
 ### 4. View the App
@@ -74,5 +67,5 @@ python3 ~/wave/test/cypress.py -m src.app
 else if you want to launch a new Wave instance automatically,
 
 ```bash
-    python3 ~/wave/test/cypress.py -m src.app -w ~/wave/waved -wd ~/wave/www
+python3 ~/wave/test/cypress.py -m src.app -w ~/wave/waved -wd ~/wave/www
 ```

--- a/sales-forecasting/Makefile
+++ b/sales-forecasting/Makefile
@@ -13,7 +13,7 @@ setup: | venv ## Setup a project
 
 .PHONY: run
 run: ## Run the App (run `make setup` first)
-	./venv/bin/wave run src.app
+	./venv/bin/wave run wave_forecast
 
 .PHONY: clean
 clean: ## Remove all files produced by `make`

--- a/sales-forecasting/Makefile
+++ b/sales-forecasting/Makefile
@@ -6,8 +6,14 @@ PYTHON     := python3
 venv:
 	$(PYTHON) -m venv venv
 
+walmart_train.csv:
+	wget https://h2o-benchmark.s3.amazonaws.com/walmart-sales-forecasting/walmart_train.csv
+
+walmart_test_preds.csv:
+	wget https://h2o-benchmark.s3.amazonaws.com/walmart-sales-forecasting/walmart_test_preds.csv
+
 .PHONY: setup
-setup: | venv ## Setup a project
+setup: | walmart_train.csv walmart_test_preds.csv venv ## Setup a project
 	./venv/bin/python -m pip install -U pip
 	./venv/bin/python -m pip install -r requirements.txt
 

--- a/sales-forecasting/README.md
+++ b/sales-forecasting/README.md
@@ -15,25 +15,15 @@ New to H2O Wave? We recommend starting in the documentation to [download and run
 ### 2. Setup Your Python Environment
 
 ```bash
-$ git clone https://github.com/h2oai/wave-apps.git
-$ cd wave-apps/sales-forecasting
-$ python3 -m venv venv
-$ source venv/bin/activate
-$ pip install -r requirements.txt
+git clone https://github.com/h2oai/wave-apps.git
+cd wave-apps/sales-forecasting
+make setup
 ```
 
-### 3. Download input data from AWS S3
-
-```console
-$ cd wave-apps/sales-forecasting
-$ wget https://h2o-benchmark.s3.amazonaws.com/walmart-sales-forecasting/walmart_train.csv
-$ wget https://h2o-benchmark.s3.amazonaws.com/walmart-sales-forecasting/walmart_test_preds.csv
-```
-
-### 4. Run the App
+### 3. Run the App
 
 ```bash
-wave run wave_forecast
+make run
 ```
 
 Note! If you did not activate your virtual environment this will be:

--- a/shopping-cart-recommendations/Makefile
+++ b/shopping-cart-recommendations/Makefile
@@ -1,22 +1,24 @@
-all: ## Build wheel
-	zip -r \
-        --exclude=".git/*" \
-        --exclude="/venv/*" \
-        --exclude="*.csv" \
-        --exclude="*__pycache__/*" \
-        $(shell basename $$PWD).qz .
+SHELL      := bash
+PYTHON     := python3
 
-setup: ## Create venv and install dependencies on it
-	python3 -m venv venv
-	./venv/bin/pip install -U pip
-	./venv/bin/pip install wheel
-	./venv/bin/pip install -r requirements.txt
+.DEFAULT_GOAL := help
 
-install: ## Install dependencies on active python environment
-	pip install -r requirements.txt
+venv:
+	$(PYTHON) -m venv venv
 
-clean: ## Clean
-	rm -rf dist venv *.whl *.qz
+.PHONY: setup
+setup: | venv ## Setup a project
+	./venv/bin/python -m pip install -U pip
+	./venv/bin/python -m pip install -r requirements.txt
 
+.PHONY: run
+run: ## Run the App (run `make setup` first)
+	./venv/bin/wave run src.app
+
+.PHONY: clean
+clean: ## Remove all files produced by `make`
+	rm -rf venv
+
+.PHONY: help
 help: ## List all make tasks
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/shopping-cart-recommendations/README.md
+++ b/shopping-cart-recommendations/README.md
@@ -18,21 +18,15 @@ New to H2O Wave? We recommend starting in the documentation to [download and run
 ### 2. Setup Your Python Environment
 
 ```bash
-$ git clone git@github.com:h2oai/wave-apps.git
-$ cd wave-apps/shopping-cart-recommendations
-$ make setup
-$ source venv/bin/activate
+git clone git@github.com:h2oai/wave-apps.git
+cd wave-apps/shopping-cart-recommendations
+make setup
 ```
 
 ### 3. Run the App
 
 ```bash
-wave run src.app
-```
-
-Note! If you did not activate your virtual environment this will be:
-```bash
-./venv/bin/wave run src.app
+make run
 ```
 
 ### 4. View the App

--- a/twitter-sentiment/Makefile
+++ b/twitter-sentiment/Makefile
@@ -1,22 +1,24 @@
-all: ## Build wheel
-	zip -r \
-        --exclude=".git/*" \
-        --exclude="/venv/*" \
-        --exclude="*.csv" \
-        --exclude="*__pycache__/*" \
-        $(shell basename $$PWD).qz .
+SHELL      := bash
+PYTHON     := python3
 
-setup: ## Create venv and install dependencies on it
-	python3 -m venv venv
-	./venv/bin/pip install -U pip
-	./venv/bin/pip install wheel
-	./venv/bin/pip install -r requirements.txt
-      
-install: ## Install dependencies on active python environment
-	pip install -r requirements.txt
+.DEFAULT_GOAL := help
 
-clean: ## Clean
-	rm -rf dist venv *.whl *.qz
+venv:
+	$(PYTHON) -m venv venv
 
+.PHONY: setup
+setup: | venv ## Setup a project
+	./venv/bin/python -m pip install -U pip
+	./venv/bin/python -m pip install -r requirements.txt
+
+.PHONY: run
+run: ## Run the App (run `make setup` first)
+	./venv/bin/wave run src.app
+
+.PHONY: clean
+clean: ## Remove all files produced by `make`
+	rm -rf venv
+
+.PHONY: help
 help: ## List all make tasks
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/twitter-sentiment/README.md
+++ b/twitter-sentiment/README.md
@@ -24,19 +24,12 @@ New to H2O Wave? We recommend starting in the documentation to [download and run
 git clone git@github.com:h2oai/wave-apps.git
 cd wave-apps/twitter-sentiment
 make setup
-source venv/bin/activate
 ```
 
 ### 3. Run the App
 
 ```bash
-wave run src.app
-```
-
-Note! If you did not activate your virtual environment this will be:
-
-```bash
-./venv/bin/wave run src.app
+make run
 ```
 
 ### 4. View the App


### PR DESCRIPTION
If PR merged, a brand new and shiny `Makefile` will be supplied to all projects. The old `Makefile` was indeed a copy from the old `Q` project not fitting quite well.

There are two notable targets in `Makefile`:
- `make setup` to set up the project, install requirements.
- `make run` to run the project (`wave` has to be running somewhere).

I tested all projects.

## Notes
- Not sure about [ARCHFLAGS](https://github.com/h2oai/wave-apps/blob/fbf37d5c3a87f74203a1969eb87f6ae05a53799e/explaining-ratings/Makefile#L13) and why it was needed in *explaining-ratings*. It works without it as well for me.
- It seems *wave-forecast* tries to download something in the first run from `S3`. It might be better to do this in the `make setup` stage without involving a *Python*. But I might not understand it well.
- Please add other reviewers if necessary.

Resolves #79