### PR TITLE
Verify and release OSS app 1.0.0

### DIFF
--- a/credit-risk/app.toml
+++ b/credit-risk/app.toml
@@ -1,6 +1,6 @@
 [App]
 Name = "ai.h2o.wave.credit-risk"
-Version = "0.3.0"
+Version = "1.1.0"
 Title = "Credit Card Risk"
 Description = "Demo for business users to review and update model predictions."
 LongDescription = "about.md"

--- a/credit-risk/app.toml
+++ b/credit-risk/app.toml
@@ -11,3 +11,4 @@ Keywords = ["FinServe", "Wave", "Open Source"]
 Module = "src.app"
 MemoryReservation = "4Gi"
 MemoryLimit = "6Gi"
+RoutingMode = "BASE_URL"

--- a/explaining-ratings/app.toml
+++ b/explaining-ratings/app.toml
@@ -1,6 +1,6 @@
 [App]
 Name = "ai.h2o.wave.explaining-ratings"
-Version = "1.0.0"
+Version = "1.1.0"
 Title = "Explainable Hotel Ratings"
 Description = "Demo to visually explore and compare predictions from text data."
 LongDescription = "about.md"

--- a/explaining-ratings/app.toml
+++ b/explaining-ratings/app.toml
@@ -11,3 +11,4 @@ Keywords = ["NLP", "Wave", "Open Source"]
 Module = "src.app"
 MemoryReservation = "4Gi"
 MemoryLimit = "6Gi"
+RoutingMode = "BASE_URL"

--- a/guess-the-number/app.toml
+++ b/guess-the-number/app.toml
@@ -10,3 +10,4 @@ Keywords = ["wave", "wave apps"]
 [Runtime]
 Module = "guess_the_number.guess"
 EnableOIDC = true
+RoutingMode = "BASE_URL"

--- a/guess-the-number/app.toml
+++ b/guess-the-number/app.toml
@@ -1,6 +1,6 @@
 [App]
 Name = "ai.h2o.wave.h2o-guess-the-number"
-Version = "0.3.0"
+Version = "1.1.0"
 Title = "Guess the Number"
 Description = "Prove you’re smarter than AI with this simple game."
 LongDescription = "about.md"

--- a/guess-the-number/requirements.txt
+++ b/guess-the-number/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2020.12.5; python_version >= "3.6" and python_full_version >= "3.6.1"
 click==7.1.2; python_full_version >= "3.6.1"
 h11==0.11.0; python_version >= "3.6" and python_full_version >= "3.6.1"
-h2o-wave<1.0; python_full_version >= "3.6.1"
+h2o-wave<1.0
 httpcore==0.12.2; python_version >= "3.6" and python_full_version >= "3.6.1"
 httpx==0.16.1; python_version >= "3.6" and python_full_version >= "3.6.1"
 idna==2.10; python_version >= "3.6" and python_full_version >= "3.6.1"

--- a/shopping-cart-recommendations/app.toml
+++ b/shopping-cart-recommendations/app.toml
@@ -1,6 +1,6 @@
 [App]
 Name = "ai.h2o.wave.shopping-cart-recommendations"
-Version = "0.3.1"
+Version = "1.1.0"
 Title = "Shopping Cart Recommendations"
 Description = "Demo of a recommendation engine on groceries items."
 LongDescription="about.md"

--- a/shopping-cart-recommendations/app.toml
+++ b/shopping-cart-recommendations/app.toml
@@ -9,3 +9,4 @@ Keywords = ["Data Science", "Wave", "Open Source", "Market Basket Analysis"]
 
 [Runtime]
 Module = "src.app"
+RoutingMode = "BASE_URL"

--- a/twitter-sentiment/app.toml
+++ b/twitter-sentiment/app.toml
@@ -1,6 +1,6 @@
 [App]
 Name = "ai.h2o.wave.twitter-sentiment"
-Version = "0.1.1"
+Version = "1.1.0"
 Title = "Twitter Sentiment"
 Description = "Search keywords on twitter and see the sentiments of the latest tweets."
 LongDescription="about.md"

--- a/twitter-sentiment/app.toml
+++ b/twitter-sentiment/app.toml
@@ -11,6 +11,7 @@ Keywords =  ["Data Science", "Wave", "Open Source", "Sentiment Analysis"]
 Module = "src.app"
 MemoryReservation = "4Gi"
 MemoryLimit = "6Gi"
+RoutingMode = "BASE_URL"
 
 [[Env]]
 Name = "ACCESS_TOKEN"


### PR DESCRIPTION
From #100 completed following tasks,
> With the release verification Let's update all the applications to support the Path-based routing reported in this [issue](https://github.com/h2oai/wave-apps/issues/96).
> 
> * [ ]  Verify and release telecom churn-risk application @VijithaEkanayake
> * [x]  Verify and release credit-risk application @VijithaEkanayake
> * [ ]  Verify and release insurance-churn-risk application @VijithaEkanayake
> * [x]  Verify and release hotel-reviews application @Nayananga
> * [x]  Verify and release the guess-the-number application @Nayananga
> * [ ]  Verify and release twitter-sentiment application @Nayananga
> * [x]  Verify and release Shopping-cart-recommondation application @Nayananga

