### PR TITLE
Feat: Add docker-compose.yml

### DIFF
--- a/docker-development/README.md
+++ b/docker-development/README.md
@@ -27,8 +27,8 @@ cd wave-apps/docker-development
 docker-compose up
 ```
 
-***Notes on networking***: in testing `host` only networking worked on Linux for docker-ce and docker-ee. But for podman one needs to add
-the `podman` network while on OSX one should use the default network.
+***Notes on networking***: in testing `host` only networking worked on Linux for *docker-ce* and *docker-ee*. But for *podman* one needs to add
+the `podman` network. While on OSX one should use the default network.
 
 TODO: Windows
 

--- a/docker-development/README.md
+++ b/docker-development/README.md
@@ -10,27 +10,25 @@ Wave is no different from other web frameworks which means you can even reuse yo
 
 ## Installation
 
-Linux / MacOS:
+Clone the repo and `cd` into corresponding directory
 
 ```sh
 git clone https://github.com/h2oai/wave-apps.git
 cd wave-apps/docker-development
+```
+
+Linux / MacOS
+
+```sh
 docker build . -t wave_local_dev
 docker run -p 10101:10101 -v $(pwd)/src:/app/src wave_local_dev:latest
 ```
 
-or via `docker compose`/`podman-compose` (with an alias of podman and podman-composee as docker and docker-compose)
+or via `docker compose`
 
 ```sh
-git clone https://github.com/h2oai/wave-apps.git
-cd wave-apps/docker-development
-docker-compose up
+docker compose up
 ```
-
-***Notes on networking***: in testing `host` only networking worked on Linux for *docker-ce* and *docker-ee*. But for *podman* one needs to add
-the `podman` network. While on OSX one should use the default network.
-
-TODO: Windows
 
 ## Features
 

--- a/docker-development/README.md
+++ b/docker-development/README.md
@@ -19,6 +19,17 @@ docker build . -t wave_local_dev
 docker run -p 10101:10101 -v $(pwd)/src:/app/src wave_local_dev:latest
 ```
 
+or via `docker compose`/`podman-compose` (with an alias of podman and podman-composee as docker and docker-compose)
+
+```sh
+git clone https://github.com/h2oai/wave-apps.git
+cd wave-apps/docker-development
+docker-compose up
+```
+
+***Notes on networking***: in testing `host` only networking worked on Linux for docker-ce and docker-ee. But for podman one needs to add
+the `podman` network while on OSX one should use the default network.
+
 TODO: Windows
 
 ## Features

--- a/docker-development/docker-compose.yml
+++ b/docker-development/docker-compose.yml
@@ -1,8 +1,5 @@
 ---
 version: '3.8'
-networks:
-  default:
-    driver: host
     
 services:
   wave_local_dev:
@@ -10,7 +7,6 @@ services:
     build: .
     ports:
       - "10101:10101/tcp"
-      - "10101:10101/udp"
     volumes:
       - ./src:/app/src
 ...

--- a/docker-development/docker-compose.yml
+++ b/docker-development/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+version: '3.8'
+networks:
+  default:
+    driver: host
+    
+services:
+  wave_local_dev:
+    image: "wave_local_dev:latest"
+    build: .
+    ports:
+      - "10101:10101/tcp"
+      - "10101:10101/udp"
+    volumes:
+      - ./src:/app/src
+...

--- a/docker-development/docker-compose.yml
+++ b/docker-development/docker-compose.yml
@@ -3,10 +3,11 @@ version: '3.8'
     
 services:
   wave_local_dev:
-    image: "wave_local_dev:latest"
-    build: .
+    build: 
+      context: .
+      dockerfile: Dockerfile
     ports:
-      - "10101:10101/tcp"
+      - "10101:10101"
     volumes:
       - ./src:/app/src
 ...

--- a/docker-development/dockerfile
+++ b/docker-development/dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.7
+# Force platform to download proper wheel (with waved included).
+# An alternative is to either download wheel manually or download and run waved separately.
+FROM --platform=linux/amd64 python:3.8
 
 # Create a project directory.
 RUN mkdir /app


### PR DESCRIPTION
**Description:**
Added docker-compose support because "docker_is_hard™" but "`docker-compose up` is for dummies®". Satire aside; I'm actually using this in production and figured it would help get the community onboarded quicker.

**Related Issues (optional):**
https://github.com/h2oai/wave/issues/1699
